### PR TITLE
Add baseFormat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ use Sourcetoad\EnhancedResources\EnhancedResource;
 
 class ExampleResource extends EnhancedResource
 {
-    //
+    public function baseFormat($request): array
+    {
+        return [
+            //
+        ];
+    }
 }
 ```
 

--- a/src/EnhancedResource.php
+++ b/src/EnhancedResource.php
@@ -96,7 +96,7 @@ abstract class EnhancedResource extends JsonResource
     protected function getFormatMethodName(): ?string
     {
         if ($this->format === null) {
-            return null;
+            return method_exists($this, 'baseFormat') ? 'baseFormat' : null;
         }
 
         return Str::camel($this->format . 'Format');


### PR DESCRIPTION
Overriding `toArray` (as is typical with base JsonResource, and with previous versions of EnhancedResources) causes enhancements to not be applied. This makes resources default to using the `baseFormat` if the method exists and no other default format was set.