### PR TITLE
Proposal: Exception type change

### DIFF
--- a/src/Exceptions/UndefinedFormatException.php
+++ b/src/Exceptions/UndefinedFormatException.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Sourcetoad\EnhancedResources\Exceptions;
 
-use Exception;
+use InvalidArgumentException;
 
-class UndefinedFormatException extends Exception
+class UndefinedFormatException extends InvalidArgumentException
 {
     public function __construct(string $resourceClass, string $format)
     {


### PR DESCRIPTION
I think we should throw an `InvalidArgumentException` when an undefined format is supplied.

I mainly want it so PhpStorm will stop complaining about uncaught exceptions every time `format` is used, but I think it makes sense beyond that.

If changing the base class on the exception is considered a breaking change, I would instead propose getting rid of `UndefinedFormatException` in the next major update and just throwing `InvalidArgumentException` in its place.