### PR TITLE
build: support prs on ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 name: tests
 on:
   push:
+  pull_request:
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To enable 3rd party PRs to run CI.